### PR TITLE
fixed number and order of retain options.

### DIFF
--- a/templates/rsnapshot.erb
+++ b/templates/rsnapshot.erb
@@ -58,9 +58,10 @@ linux_lvm_cmd_umount	<%= @linux_lvm_cmd_umount %>
 # i.e. hourly, daily, weekly, etc.      #
 #########################################
 
-<% @retain.each do |name, time| -%>
-retain	<%= name %>	<%= time %>
-<% end -%>
+retain	hourly	<%= retain['hourly'] %>
+retain	daily	<%= retain['daily'] %>
+retain	weekly	<%= retain['weekly'] %>
+retain	monthly	<%= retain['monthly'] %>
 
 ############################################
 #              GLOBAL OPTIONS              #


### PR DESCRIPTION
I changed the hash with the retain options. In my case the order of options was changed, when iterating of the entries in the template file. The 'monthly' option was set as the first option.

```
retain monthly 12
retain hourly 4
retain daily 7
retain weekly 4
```

With this (valid) configuration no `rsnapshot hourly`, `rsnapshot daily` or `rsnapshot weekly` works any more.

I removed the iteration over the hash `rsnapshot::retain` and inserted fixed references in the correct order instead.
